### PR TITLE
Remove bcc emails

### DIFF
--- a/backend/src/LeanCode.AppRating/Configuration/AppRatingReportsConfiguration.cs
+++ b/backend/src/LeanCode.AppRating/Configuration/AppRatingReportsConfiguration.cs
@@ -5,6 +5,5 @@ public sealed record class AppRatingReportsConfiguration(
     string LowRatingEmailCulture,
     string LowRatingEmailSubjectKey,
     string FromEmail,
-    string[] ToEmails,
-    string[] BccEmails
+    string[] ToEmails
 ) { }

--- a/backend/src/LeanCode.AppRating/Handlers/SendEmailOnLowRateSubmittedEH.cs
+++ b/backend/src/LeanCode.AppRating/Handlers/SendEmailOnLowRateSubmittedEH.cs
@@ -38,9 +38,6 @@ public class SendEmailOnLowRateSubmittedEH<TUserId> : IConsumer<LowRateSubmitted
             .WithRecipients(
                 appRatingReportsConfiguration.ToEmails.Select(e => new EmailAddress() { Email = e, }).ToList()
             )
-            .WithBlindCarbonCopyRecipients(
-                appRatingReportsConfiguration.BccEmails.Select(e => new EmailAddress() { Email = e, }).ToList()
-            )
             .WithHtmlContent(vm)
             .WithPlainTextContent(vm)
             .WithNoTracking();

--- a/backend/tests/LeanCode.AppRating.IntegrationTests/App/Startup.cs
+++ b/backend/tests/LeanCode.AppRating.IntegrationTests/App/Startup.cs
@@ -57,14 +57,7 @@ public class Startup : LeanStartup
         services.AddSingleton(sendGridRazorClientMock);
 
         services.AddSingleton(
-            new AppRatingReportsConfiguration(
-                2.0,
-                "en",
-                "subject",
-                "test+from@leancode.pl",
-                [ "test+to@leancode.pl" ],
-                [ "test+bcc@leancode.pl" ]
-            )
+            new AppRatingReportsConfiguration(2.0, "en", "subject", "test+from@leancode.pl", [ "test+to@leancode.pl" ])
         );
 
         services.AddBusActivityMonitor();


### PR DESCRIPTION
Reasoning behind this change:

Sending CC/BCC in this case do not give us much value, since we want to inform the back-office team only. Their emails are most likely already known to everyone within the organization. 
Current implementation does not work (at least one email is required by the API) and I don't see value in fixing it (I know - one `if`). Removing it benefits us in simpler configuration => dev won't need to thing which emails should be to/cc/bcc at all.