### PR TITLE
Allow review from unauthorized users

### DIFF
--- a/backend/Directory.Build.targets
+++ b/backend/Directory.Build.targets
@@ -13,6 +13,7 @@
     <PackageReference Update="LeanCode.CQRS.MassTransitRelay" Version="$(CoreLibVersion)" />
     <PackageReference Update="LeanCode.CQRS.Validation.Fluent" Version="$(CoreLibVersion)" />
     <PackageReference Update="LeanCode.DomainModels.EF" Version="$(CoreLibVersion)" />
+    <PackageReference Update="LeanCode.DomainModels.Generators" Version="$(CoreLibVersion)" />
     <PackageReference Update="LeanCode.SendGrid" Version="$(CoreLibVersion)" />
     <PackageReference Update="LeanCode.TimeProvider" Version="$(CoreLibVersion)" />
   </ItemGroup>

--- a/backend/src/LeanCode.AppRating.Contracts/SubmitAppRating.cs
+++ b/backend/src/LeanCode.AppRating.Contracts/SubmitAppRating.cs
@@ -3,7 +3,7 @@ using LeanCode.Contracts.Security;
 
 namespace LeanCode.AppRating.Contracts;
 
-[AuthorizeWhenHasAnyOf(RatingPermissions.RateApp)]
+[AllowUnauthorized]
 public class SubmitAppRating : ICommand
 {
     public double Rating { get; set; }

--- a/backend/src/LeanCode.AppRating/DataAccess/AppRating.cs
+++ b/backend/src/LeanCode.AppRating/DataAccess/AppRating.cs
@@ -1,9 +1,14 @@
 using System.Collections.Immutable;
+using LeanCode.DomainModels.Ids;
 
 namespace LeanCode.AppRating.DataAccess;
 
+[TypedId(TypedIdFormat.RawGuid)]
+public readonly partial record struct AppRatingId;
+
 public sealed record class AppRating<TUserId>(
-    TUserId UserId,
+    AppRatingId Id,
+    TUserId? UserId,
     DateTimeOffset DateCreated,
     double Rating,
     string? AdditionalComment,

--- a/backend/src/LeanCode.AppRating/DataAccess/ModelBuilderExtensions.cs
+++ b/backend/src/LeanCode.AppRating/DataAccess/ModelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using LeanCode.DomainModels.EF;
 using Microsoft.EntityFrameworkCore;
 
 namespace LeanCode.AppRating.DataAccess;
@@ -11,7 +12,10 @@ public static class ModelBuilderExtensions
     {
         builder.Entity<AppRating<TUserId>>(c =>
         {
-            c.HasKey(e => new { e.UserId, e.DateCreated });
+            c.HasKey(e => e.Id);
+            c.Property(e => e.Id).HasConversion<RawTypedIdConverter<Guid, AppRatingId>>();
+
+            c.HasIndex(e => new { e.UserId, e.DateCreated });
 
             c.Property(e => e.UserId).ValueGeneratedNever();
 

--- a/backend/src/LeanCode.AppRating/EmailViewModels/LowRateSubmittedEmail.cs
+++ b/backend/src/LeanCode.AppRating/EmailViewModels/LowRateSubmittedEmail.cs
@@ -3,6 +3,6 @@ namespace LeanCode.AppRating.EmailViewModels;
 public class LowRateSubmittedEmail
 {
     public double Rating { get; set; }
-    public string UserId { get; set; } = null!;
+    public string? UserId { get; set; }
     public string? AdditionalComment { get; set; }
 }

--- a/backend/src/LeanCode.AppRating/Handlers/RatingAlreadySentQH.cs
+++ b/backend/src/LeanCode.AppRating/Handlers/RatingAlreadySentQH.cs
@@ -20,9 +20,13 @@ public class RatingAlreadySentQH<TUserId> : IQueryHandler<RatingAlreadySent, boo
 
     public Task<bool> ExecuteAsync(HttpContext context, RatingAlreadySent query)
     {
-        return store
-            .AppRatings
-            .Where(r => (object)r.UserId == (object)extractor.Extract(context))
-            .AnyAsync(context.RequestAborted);
+        if (extractor.TryExtract(context, out var userId))
+        {
+            return store.AppRatings.Where(r => (object?)r.UserId == (object?)userId).AnyAsync(context.RequestAborted);
+        }
+        else
+        {
+            throw new InvalidOperationException("UserId could not be extracted.");
+        }
     }
 }

--- a/backend/src/LeanCode.AppRating/Handlers/RatingAlreadySentQH.cs
+++ b/backend/src/LeanCode.AppRating/Handlers/RatingAlreadySentQH.cs
@@ -20,13 +20,9 @@ public class RatingAlreadySentQH<TUserId> : IQueryHandler<RatingAlreadySent, boo
 
     public Task<bool> ExecuteAsync(HttpContext context, RatingAlreadySent query)
     {
-        if (extractor.TryExtract(context, out var userId))
-        {
-            return store.AppRatings.Where(r => (object?)r.UserId == (object?)userId).AnyAsync(context.RequestAborted);
-        }
-        else
-        {
-            throw new InvalidOperationException("UserId could not be extracted.");
-        }
+        return store
+            .AppRatings
+            .Where(r => (object?)r.UserId == (object?)extractor.Extract(context))
+            .AnyAsync(context.RequestAborted);
     }
 }

--- a/backend/src/LeanCode.AppRating/Handlers/SendEmailOnLowRateSubmittedEH.cs
+++ b/backend/src/LeanCode.AppRating/Handlers/SendEmailOnLowRateSubmittedEH.cs
@@ -27,7 +27,7 @@ public class SendEmailOnLowRateSubmittedEH<TUserId> : IConsumer<LowRateSubmitted
     {
         var vm = new LowRateSubmittedEmail
         {
-            UserId = context.Message.UserId.ToString()!,
+            UserId = context.Message.UserId?.ToString(),
             AdditionalComment = context.Message.AdditionalComment,
             Rating = context.Message.Rating,
         };
@@ -47,5 +47,5 @@ public class SendEmailOnLowRateSubmittedEH<TUserId> : IConsumer<LowRateSubmitted
     }
 }
 
-public sealed record class LowRateSubmitted<TUserId>(TUserId UserId, double Rating, string? AdditionalComment)
+public sealed record class LowRateSubmitted<TUserId>(TUserId? UserId, double Rating, string? AdditionalComment)
     where TUserId : notnull, IEquatable<TUserId>;

--- a/backend/src/LeanCode.AppRating/Handlers/SubmitAppRatingCH.cs
+++ b/backend/src/LeanCode.AppRating/Handlers/SubmitAppRatingCH.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Runtime.InteropServices;
 using FluentValidation;
 using LeanCode.AppRating.Configuration;
 using LeanCode.AppRating.Contracts;
@@ -59,12 +58,13 @@ public class SubmitAppRatingCH<TUserId> : ICommandHandler<SubmitAppRating>
 
     public async Task ExecuteAsync(HttpContext context, SubmitAppRating command)
     {
-        var userId = extractor.Extract(context);
+        var userId = extractor.TryExtract(context, out var uid) ? uid : default;
 
         store
             .AppRatings
             .Add(
                 new AppRating<TUserId>(
+                    AppRatingId.New(),
                     userId,
                     Time.NowWithOffset,
                     command.Rating,

--- a/backend/src/LeanCode.AppRating/IUserIdExtractor.cs
+++ b/backend/src/LeanCode.AppRating/IUserIdExtractor.cs
@@ -5,4 +5,12 @@ namespace LeanCode.AppRating;
 public interface IUserIdExtractor<TUserId>
 {
     public bool TryExtract(HttpContext httpContext, out TUserId? userId);
+    public TUserId Extract(HttpContext httpContext)
+    {
+        if (!TryExtract(httpContext, out var userId))
+        {
+            throw new InvalidOperationException("UserId could not be extracted.");
+        }
+        return userId!;
+    }
 }

--- a/backend/src/LeanCode.AppRating/IUserIdExtractor.cs
+++ b/backend/src/LeanCode.AppRating/IUserIdExtractor.cs
@@ -4,5 +4,5 @@ namespace LeanCode.AppRating;
 
 public interface IUserIdExtractor<TUserId>
 {
-    public TUserId Extract(HttpContext httpContext);
+    public bool TryExtract(HttpContext httpContext, out TUserId? userId);
 }

--- a/backend/src/LeanCode.AppRating/LeanCode.AppRating.csproj
+++ b/backend/src/LeanCode.AppRating/LeanCode.AppRating.csproj
@@ -1,10 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="LeanCode.Components" />
     <PackageReference Include="LeanCode.CQRS.AspNetCore" />
     <PackageReference Include="LeanCode.CQRS.Execution" />
     <PackageReference Include="LeanCode.CQRS.MassTransitRelay" />
     <PackageReference Include="LeanCode.CQRS.Validation.Fluent" />
+    <PackageReference Include="LeanCode.DomainModels.EF" />
+    <PackageReference Include="LeanCode.DomainModels.Generators" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <PackageReference Include="LeanCode.SendGrid" />
     <PackageReference Include="LeanCode.TimeProvider" />
 

--- a/backend/src/LeanCode.AppRating/LeanCode.AppRating.csproj
+++ b/backend/src/LeanCode.AppRating/LeanCode.AppRating.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="LeanCode.Components" />
     <PackageReference Include="LeanCode.CQRS.AspNetCore" />

--- a/backend/tests/LeanCode.AppRating.IntegrationTests/App/Startup.cs
+++ b/backend/tests/LeanCode.AppRating.IntegrationTests/App/Startup.cs
@@ -83,12 +83,12 @@ public class Startup : LeanStartup
 
 public sealed class UserIdExtractor : IUserIdExtractor<Guid>
 {
-    public Guid Extract(HttpContext httpContext)
+    public bool TryExtract(HttpContext httpContext, out Guid userId)
     {
         var claim = httpContext.User.FindFirstValue(KnownClaims.UserId);
 
         ArgumentException.ThrowIfNullOrEmpty(claim);
 
-        return Guid.Parse(claim);
+        return Guid.TryParse(claim, out userId);
     }
 }

--- a/backend/tests/LeanCode.AppRating.IntegrationTests/TestDatabaseConfig.cs
+++ b/backend/tests/LeanCode.AppRating.IntegrationTests/TestDatabaseConfig.cs
@@ -1,6 +1,4 @@
 using LeanCode.AppRating.DataAccess;
-using LeanCode.CQRS.MassTransitRelay.LockProviders;
-using LeanCode.DomainModels.EF;
 using LeanCode.IntegrationTestHelpers;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;

--- a/backend/tests/LeanCode.AppRating.IntegrationTests/Tests/SubmitReviewTests.cs
+++ b/backend/tests/LeanCode.AppRating.IntegrationTests/Tests/SubmitReviewTests.cs
@@ -1,12 +1,11 @@
 using FluentAssertions;
 using LeanCode.AppRating.Contracts;
-using LeanCode.AppRating.IntegrationTests;
 using LeanCode.AppRating.IntegrationTests.App;
 using LeanCode.AppRating.IntegrationTests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace LeanCode.NotificationCenter.IntegrationTests.Tests;
+namespace LeanCode.AppRating.IntegrationTests.Tests;
 
 public class SubmitReviewTests : TestsBase<TestApp>
 {

--- a/backend/tests/LeanCode.AppRating.Tests/CQRS/SubmitAppRatingCVTests.cs
+++ b/backend/tests/LeanCode.AppRating.Tests/CQRS/SubmitAppRatingCVTests.cs
@@ -3,7 +3,7 @@ using LeanCode.AppRating.Contracts;
 using LeanCode.AppRating.Handlers;
 using Xunit;
 
-namespace LeanCode.AppRating.Tests;
+namespace LeanCode.AppRating.Tests.CQRS;
 
 public class SubmitAppRatingCVTests
 {


### PR DESCRIPTION
There is a new requirement, that forces us to reconfigure most of the storage part of the rating feature. I'm not sure how we want to approach the data migration to the new backend version (do we care at all?). 

Decisions made on the fly:
- Unauthorized user is unable to check if they already submitted the review.
- We don't want to use prefixed id for AppRatingId - this would require yet another configuration on the package user side.
- For unauthorized users the default value for UserId will be provided (this is especially important when used with `struct`s).

Tests for unauthorized user are missing...