### PR TITLE
Update corelibrary and dependent packages

### DIFF
--- a/backend/Directory.Build.targets
+++ b/backend/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <CoreLibVersion>10.0.2709-preview</CoreLibVersion>
-    <EFCoreVersion>10.0.0-rc.2.25502.107</EFCoreVersion>
+    <CoreLibVersion>10.0.2808-preview</CoreLibVersion>
+    <EFCoreVersion>10.0.1</EFCoreVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Update="FluentValidation" Version="12.1.0" />
-    <PackageReference Update="MassTransit" Version="8.5.5" />
+    <PackageReference Update="MassTransit" Version="8.5.7" />
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
-    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Update="Serilog" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
https://github.com/leancodepl/corelibrary/pull/813 changed  `Parse(string v)` to ` Parse(string v, IFormatProvider? provider = null)` which is crashing migrations when attempting to update Example App 

```
Unable to create a 'DbContext' of type 'ExamplesDbContext'. The exception 'Virtual static method 'Parse' is not implemented on type 'LeanCode.AppRating.DataAccess.AppRatingId' from assembly 'LeanCode.AppRating, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.' was thrown while attempting to create an instance. 
```